### PR TITLE
Handling pagination for card search API call

### DIFF
--- a/SpellGallery/Scryfall/Models/SearchResponse.cs
+++ b/SpellGallery/Scryfall/Models/SearchResponse.cs
@@ -1,5 +1,6 @@
 ﻿#region Using Directives
 
+using Newtonsoft.Json;
 using System.Collections.Generic;
 
 #endregion
@@ -15,5 +16,11 @@ namespace SpellGallery.Scryfall.Models
         /// A list of cards returned from a card search
         /// </summary>
         public List<Card> Data { get; set; }
+
+        /// <summary>
+        /// An optional URL pointing to the next page of output
+        /// </summary>
+        [JsonProperty("next_page")]
+        public string NextPage { get; set; }
     }
 }

--- a/SpellGallery/Scryfall/ScryfallMethods.cs
+++ b/SpellGallery/Scryfall/ScryfallMethods.cs
@@ -36,9 +36,17 @@ namespace SpellGallery.Scryfall
         /// <returns>List of cards</returns>
         public static async Task<List<Card>> GetCardsByNameAsync(string cardName)
         {
-            string endpoint = $"/cards/search?unique=prints&q=!{Uri.EscapeUriString($"\"{cardName}\"")}";
-            var searchResponse = await GetAsync<SearchResponse>(endpoint);
-            return searchResponse.Data;
+            List<Card> cards = new List<Card>();
+            string url = $"{ApiUrl}/cards/search?unique=prints&q=!{Uri.EscapeUriString($"\"{cardName}\"")}";
+
+            while (!String.IsNullOrEmpty(url))
+            {
+                var response = await GetAsync<SearchResponse>(url);
+                cards.AddRange(response.Data);
+                url = response.NextPage;
+            }
+
+            return cards;
         }
 
         /// <summary>
@@ -48,15 +56,14 @@ namespace SpellGallery.Scryfall
         /// <returns>List of suggestions that meet the filter criteria</returns>
         public static async Task<List<string>> AutoCompleteAsync(string filter)
         {
-            string endpoint = $"/cards/autocomplete?q={Uri.EscapeUriString(filter)}";
-            var autoCompleteResponse = await GetAsync<AutoCompleteResponse>(endpoint);
+            string url = $"{ApiUrl}/cards/autocomplete?q={Uri.EscapeUriString(filter)}";
+            var autoCompleteResponse = await GetAsync<AutoCompleteResponse>(url);
             return autoCompleteResponse.Data;
         }
 
         // GET REST operation helper
-        private static async Task<T> GetAsync<T>(string endpoint)
+        private static async Task<T> GetAsync<T>(string url)
         {
-            string url = $"{ApiUrl}{endpoint}";
             var response = await HttpClient.GetAsync(url);
             string responseString = await response.Content.ReadAsStringAsync();
 


### PR DESCRIPTION
### Description
Adding logic to handle pagination for the scryfall card search API. I noticed when trying to update the art for basic islands that only the first 175 results are shown ([API reference mentioning this](https://scryfall.com/docs/api/cards/search)). After this commit, any card that has more than 175 unique arts, which I imagine only applies to basic lands, will have all possible arts shown in the tool.

### Testing
Tested manually by searching for Island. Below is a screenshot before and after this change, note the size of the scroll bar indicating the big disparity in results returned between the search. I also scrolled down to show some of the extra results that won't be shown before this change, so you can compare on your end as well. I did a tiny bit of regression testing with random cards to make sure there's no issues with calls that won't have any results beyond the first page.

**Before**
![image](https://github.com/user-attachments/assets/e5ddb5a6-4341-4501-aa4a-ab90bb6ff589)

**After**
![image](https://github.com/user-attachments/assets/2fe5c2a8-a2fa-4e61-8d95-2902f6c552b5)

### Additional Notes
Thanks a ton for making this tool! Let me know if there's any additional testing requirements and I can update this PR with the results.

### References
* Search API reference - [scryfall link](https://scryfall.com/docs/api/cards/search)
* List Objects reference for pagination - [scryfall link](https://scryfall.com/docs/api/lists)
